### PR TITLE
Change patches extra name

### DIFF
--- a/src/Netresearch/Composer/Patches/Plugin.php
+++ b/src/Netresearch/Composer/Patches/Plugin.php
@@ -169,14 +169,14 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 		$patchSets = array();
 		foreach ($packages as $package) {
 			$extra = $package->getExtra();
-			if (isset($extra['patches']) && $initialPackage->getName() != $package->getName()) {
-				$patchSets[$package->getName()] = array($extra['patches'], array($initialPackage));
+			if (isset($extra['patches_core']) && $initialPackage->getName() != $package->getName()) {
+				$patchSets[$package->getName()] = array($extra['patches_core'], array($initialPackage));
 			}
 		}
 
 		$extra = $initialPackage->getExtra();
-		if (isset($extra['patches'])) {
-			$patchSets[$initialPackage->getName()] = array($extra['patches'], $packages);
+		if (isset($extra['patches_core'])) {
+			$patchSets[$initialPackage->getName()] = array($extra['patches_core'], $packages);
 		}
 
 		$patchesAndPackages = array();


### PR DESCRIPTION
cweagans/composer-patches and composer-patches-plugin are using the same extra patches name. When patching core cweagans/composer-patches deleted docroot with all subfolders, which is bad. So we change the patches extra name to use composer-patches-plugin for CORE and keep using cweagans/composer-patches for contrib.

See issues on composer-patches:
https://github.com/cweagans/composer-patches/issues/42
https://github.com/cweagans/composer-patches/issues/26
